### PR TITLE
Add benchmark suite and plan runner

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
-node_modules
+node_modules/
+results/

--- a/benchmarks/libs_comparison.js
+++ b/benchmarks/libs_comparison.js
@@ -1,0 +1,76 @@
+import { Polygon } from '../src/navmesh/Polygon.js';
+import { Graph } from '../src/pathfinding/Graph.js';
+import { Pathfinder } from '../src/pathfinding/Pathfinder.js';
+import PF from 'pathfinding';
+import { Graph as YukaGraph, NavNode, NavEdge, AStar as YukaAStar, Vector3 } from 'yuka';
+import { performance } from 'perf_hooks';
+
+function buildGridGraph(w, h) {
+  const nodes = [];
+  for (let y = 0; y < h; y++) {
+    for (let x = 0; x < w; x++) {
+      const id = y * w + x;
+      const poly = new Polygon([
+        { x, y },
+        { x: x + 1, y },
+        { x: x + 1, y: y + 1 },
+        { x, y: y + 1 },
+      ]);
+      nodes.push({ id, polygon: poly });
+    }
+  }
+  const edges = [];
+  for (let y = 0; y < h; y++) {
+    for (let x = 0; x < w; x++) {
+      const id = y * w + x;
+      if (x < w - 1) edges.push([id, id + 1, 1]);
+      if (y < h - 1) edges.push([id, id + w, 1]);
+    }
+  }
+  return new Graph(nodes, edges);
+}
+
+function buildYukaGraph(w, h) {
+  const graph = new YukaGraph();
+  for (let y = 0; y < h; y++) {
+    for (let x = 0; x < w; x++) {
+      const id = y * w + x;
+      const node = new NavNode(id, new Vector3(x, 0, y));
+      graph.addNode(node);
+    }
+  }
+  for (let y = 0; y < h; y++) {
+    for (let x = 0; x < w; x++) {
+      const id = y * w + x;
+      if (x < w - 1) graph.addEdge(new NavEdge(id, id + 1, 1));
+      if (y < h - 1) graph.addEdge(new NavEdge(id, id + w, 1));
+    }
+  }
+  return graph;
+}
+
+const SIZE = 200;
+const mpGraph = buildGridGraph(SIZE, SIZE);
+const startId = 0;
+const endId = SIZE * SIZE - 1;
+
+let t0 = performance.now();
+Pathfinder.findPath({ graph: mpGraph, start: startId, end: endId });
+const mpTime = performance.now() - t0;
+
+const grid = new PF.Grid(SIZE, SIZE);
+const finder = new PF.AStarFinder();
+t0 = performance.now();
+finder.findPath(0, 0, SIZE - 1, SIZE - 1, grid);
+const pfTime = performance.now() - t0;
+
+const yGraph = buildYukaGraph(SIZE, SIZE);
+const astar = new YukaAStar(yGraph, startId, endId);
+t0 = performance.now();
+astar.search();
+astar.getPath();
+const yTime = performance.now() - t0;
+
+console.log(`mesh-pilot → ${mpTime.toFixed(2)} ms`);
+console.log(`pathfinding.js → ${pfTime.toFixed(2)} ms`);
+console.log(`yuka → ${yTime.toFixed(2)} ms`);

--- a/benchmarks/navmesh_npcs.js
+++ b/benchmarks/navmesh_npcs.js
@@ -1,0 +1,48 @@
+import { Polygon } from '../src/navmesh/Polygon.js';
+import { Graph } from '../src/pathfinding/Graph.js';
+import { Pathfinder } from '../src/pathfinding/Pathfinder.js';
+import { performance } from 'perf_hooks';
+
+function buildGridGraph(w, h) {
+  const nodes = [];
+  for (let y = 0; y < h; y++) {
+    for (let x = 0; x < w; x++) {
+      const id = y * w + x;
+      const poly = new Polygon([
+        { x, y },
+        { x: x + 1, y },
+        { x: x + 1, y: y + 1 },
+        { x, y: y + 1 },
+      ]);
+      nodes.push({ id, polygon: poly });
+    }
+  }
+  const edges = [];
+  for (let y = 0; y < h; y++) {
+    for (let x = 0; x < w; x++) {
+      const id = y * w + x;
+      if (x < w - 1) edges.push([id, id + 1, 1]);
+      if (y < h - 1) edges.push([id, id + w, 1]);
+    }
+  }
+  return new Graph(nodes, edges);
+}
+
+const WIDTH = 50;
+const HEIGHT = 200;
+const graph = buildGridGraph(WIDTH, HEIGHT);
+
+const ITERATIONS = 10;
+const AGENTS = 10;
+let total = 0;
+for (let i = 0; i < ITERATIONS; i++) {
+  const t0 = performance.now();
+  for (let j = 0; j < AGENTS; j++) {
+    const start = Math.floor(Math.random() * WIDTH * HEIGHT);
+    const end = Math.floor(Math.random() * WIDTH * HEIGHT);
+    Pathfinder.findPath({ graph, start, end });
+  }
+  total += performance.now() - t0;
+}
+const avg = total / ITERATIONS;
+console.log(`NavMesh × ${AGENTS} NPCs → ${avg.toFixed(2)} ms/run`);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,16 +1,18 @@
 {
   "name": "mesh-pilot",
-  "version": "1.0.0",
+  "version": "1.1.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mesh-pilot",
-      "version": "1.0.0",
+      "version": "1.1.5",
       "license": "MIT",
       "dependencies": {
         "path-browserify": "^1.0.1",
-        "url": "^0.11.4"
+        "pathfinding": "^0.4.18",
+        "url": "^0.11.4",
+        "yuka": "^0.7.8"
       },
       "devDependencies": {
         "@babel/core": "^7.27.4",
@@ -5222,6 +5224,11 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/heap": {
+      "version": "0.2.5",
+      "resolved": "https://registry.npmjs.org/heap/-/heap-0.2.5.tgz",
+      "integrity": "sha512-G7HLD+WKcrOyJP5VQwYZNC3Z6FcQ7YYjEFiFoIj8PfEr73mu421o8B1N5DKUcc8K37EsJ2XXWA8DtrDz/2dReg=="
+    },
     "node_modules/html-encoding-sniffer": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-4.0.0.tgz",
@@ -6899,6 +6906,14 @@
       "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
       "dev": true
     },
+    "node_modules/pathfinding": {
+      "version": "0.4.18",
+      "resolved": "https://registry.npmjs.org/pathfinding/-/pathfinding-0.4.18.tgz",
+      "integrity": "sha512-R0TGEQ9GRcFCDvAWlJAWC+KGJ9SLbW4c0nuZRcioVlXVTlw+F5RvXQ8SQgSqI9KXWC1ew95vgmIiyaWTlCe9Ag==",
+      "dependencies": {
+        "heap": "0.2.5"
+      }
+    },
     "node_modules/picocolors": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
@@ -8383,6 +8398,12 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/yuka": {
+      "version": "0.7.8",
+      "resolved": "https://registry.npmjs.org/yuka/-/yuka-0.7.8.tgz",
+      "integrity": "sha512-G/pFcMZh2Azz7Yy500NSV1jQ0Ru7h9hTNyEW+HjRXcdzjJIyp/3mCGspnx7VJVP06zxORqK6mkl5TywLqVUnVg==",
+      "license": "MIT"
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -16,7 +16,9 @@
   "types": "./dist/mesh-pilot.d.ts",
   "dependencies": {
     "path-browserify": "^1.0.1",
-    "url": "^0.11.4"
+    "pathfinding": "^0.4.18",
+    "url": "^0.11.4",
+    "yuka": "^0.7.8"
   },
   "babel": {
     "presets": [
@@ -51,7 +53,8 @@
     "docs": "typedoc",
     "prepare": "npm run build:js",
     "pretest": "npm run build:js",
-    "prepublishOnly": "npm run build"
+    "prepublishOnly": "npm run build",
+    "plan": "node scripts/execPlan.js"
   },
   "files": [
     "dist/",

--- a/scripts/execPlan.js
+++ b/scripts/execPlan.js
@@ -1,0 +1,46 @@
+import { spawnSync } from 'child_process';
+import { performance } from 'perf_hooks';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+
+const resultsDir = path.resolve('results');
+fs.mkdirSync(resultsDir, { recursive: true });
+
+const env = {
+  cpu: os.cpus()[0].model,
+  cores: os.cpus().length,
+  ramGB: Math.round(os.totalmem() / 1e9),
+  platform: process.platform,
+  node: process.version,
+};
+fs.writeFileSync(path.join(resultsDir, 'env.json'), JSON.stringify(env, null, 2));
+
+const times = {};
+
+function runTimed(cmd, args) {
+  const t0 = performance.now();
+  const result = spawnSync(cmd, args, { encoding: 'utf8' });
+  process.stdout.write(result.stdout);
+  process.stderr.write(result.stderr);
+  const elapsed = performance.now() - t0;
+  if (result.status !== 0) process.exit(result.status);
+  return { output: result.stdout, time: elapsed };
+}
+
+let res = runTimed('npm', ['test']);
+times['Jest'] = res.time;
+
+res = runTimed('node', ['benchmarks/navmesh_npcs.js']);
+const m1 = res.output.match(/NPCs → ([\d.]+) ms\/run/);
+times['Benchmark NPCs'] = m1 ? parseFloat(m1[1]) : res.time;
+
+res = runTimed('node', ['benchmarks/libs_comparison.js']);
+const libs = {};
+for (const line of res.output.trim().split(/\r?\n/)) {
+  const parts = line.split(' → ');
+  if (parts.length === 2) libs[parts[0]] = parseFloat(parts[1]);
+}
+times['Benchmark Libs'] = libs;
+
+fs.writeFileSync(path.join(resultsDir, 'times.json'), JSON.stringify(times, null, 2));


### PR DESCRIPTION
## Summary
- create benchmark scripts for NPC load and lib comparison
- add execution plan to gather env info and benchmark times
- ignore results folder
- wire up new `plan` npm script

## Testing
- `node scripts/execPlan.js`

------
https://chatgpt.com/codex/tasks/task_e_685a7f132c808330816f8bbf89e23d9a